### PR TITLE
Fixed default GLES2 RenderTarget depth buffer precision bits being to…

### DIFF
--- a/McEngine/src/Engine/Renderer/OpenGLRenderTarget.cpp
+++ b/McEngine/src/Engine/Renderer/OpenGLRenderTarget.cpp
@@ -87,7 +87,7 @@ void OpenGLRenderTarget::init()
 
 #else
 
-	glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH_COMPONENT16, (int)m_vSize.x, (int)m_vSize.y);
+	glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH_COMPONENT24, (int)m_vSize.x, (int)m_vSize.y);
 
 #endif
 


### PR DESCRIPTION
…o low at 16 instead of 24